### PR TITLE
fix/consider datalake input as id instead of name in split video to frames processing

### DIFF
--- a/pipelines/convert_videos_to_frames/steps.py
+++ b/pipelines/convert_videos_to_frames/steps.py
@@ -112,7 +112,7 @@ def upload_frames_and_create_dataset(
     if not version_name:
         raise ValueError("Input 'output_dataset_version_name' is required.")
 
-    datalake = context.client.get_datalake(name=context.inputs.get("datalake"))
+    datalake = context.client.get_datalake_by_id(name=context.inputs.get("datalake"))
 
     frame_images = frames_coco.get("images", [])
 

--- a/pipelines/convert_videos_to_frames/steps.py
+++ b/pipelines/convert_videos_to_frames/steps.py
@@ -112,7 +112,7 @@ def upload_frames_and_create_dataset(
     if not version_name:
         raise ValueError("Input 'output_dataset_version_name' is required.")
 
-    datalake = context.client.get_datalake_by_id(name=context.inputs.get("datalake"))
+    datalake = context.client.get_datalake(id=context.inputs.get("datalake"))
 
     frame_images = frames_coco.get("images", [])
 

--- a/tests/convert_videos_to_frames/run_config.toml
+++ b/tests/convert_videos_to_frames/run_config.toml
@@ -9,7 +9,7 @@ type = "DATASET_VERSION_CREATION"
 
 [inputs]
 output_dataset_version_name = "Video_frames"
-datalake = "default"
+datalake = "019a5df4-9465-7683-9f74-c3182e498288"
 
 [input.dataset_version]
 id = "019f21dd-6102-76f2-bafb-4658d00a5c31"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video frame uploads by retrieving the configured data lake reliably using its unique identifier.
  * Updated the conversion job configuration to use the correct data lake identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->