### PR TITLE
fix: resolve annotation-to-video scale lookup and add dimension logging

### DIFF
--- a/pipelines/convert_videos_to_frames/steps.py
+++ b/pipelines/convert_videos_to_frames/steps.py
@@ -43,6 +43,10 @@ def download_videos() -> tuple[list, str, dict[str, Any]]:
 
     for asset in video_assets:
         asset.download(target_path=videos_dir, force_replace=True)
+        print(
+            f"[dims] asset '{asset.filename}' (id={asset.id}): "
+            f"width={asset.width}, height={asset.height}"
+        )
     print(f"Downloaded {len(video_assets)} video(s) to '{videos_dir}'.")
 
     coco_dir = os.path.join(context.working_dir, "annotations", "input")
@@ -63,6 +67,17 @@ def download_videos() -> tuple[list, str, dict[str, Any]]:
         f"{len(video_coco_data.get('images', []))} annotated frame(s), "
         f"{len(video_coco_data.get('annotations', []))} annotation(s)."
     )
+    for img in video_coco_data.get("images", []):
+        print(
+            f"[dims] video COCO 'images' entry {img.get('id')} "
+            f"(video_id={img.get('video_id')}, frame_id={img.get('frame_id')}): "
+            f"width={img.get('width')}, height={img.get('height')}"
+        )
+    if video_coco_data.get("annotations"):
+        print(
+            f"[dims] sample annotation keys: "
+            f"{sorted(video_coco_data['annotations'][0].keys())}"
+        )
     return video_assets, videos_dir, video_coco_data
 
 

--- a/pipelines/convert_videos_to_frames/utils/processing.py
+++ b/pipelines/convert_videos_to_frames/utils/processing.py
@@ -59,11 +59,16 @@ def extract_frames_and_build_coco(
 
     # (video_id, frame_id) -> old image_id in the video COCO
     annotated_key_to_old_image_id: dict[tuple[int, int], int] = {}
+    # old image_id -> video_id, since annotations only carry image_id, not
+    # video_id, and we need to know which video's scale factor to apply.
+    old_image_id_to_video_id: dict[int, int] = {}
     for img in video_coco_data.get("images", []):
         vid = img.get("video_id")
         fid = img.get("frame_id")
         if vid is not None and fid is not None:
             annotated_key_to_old_image_id[(vid, fid)] = img["id"]
+        if vid is not None:
+            old_image_id_to_video_id[img["id"]] = vid
 
     frames_coco: dict[str, Any] = {
         "images": [],
@@ -101,9 +106,14 @@ def extract_frames_and_build_coco(
                 annotated_w, annotated_h = video_id_to_annotated_dims.get(
                     vid_id, (None, None)
                 )
-                video_id_to_scale[vid_id] = (
-                    w / annotated_w if annotated_w else 1.0,
-                    h / annotated_h if annotated_h else 1.0,
+                scale_x = w / annotated_w if annotated_w else 1.0
+                scale_y = h / annotated_h if annotated_h else 1.0
+                video_id_to_scale[vid_id] = (scale_x, scale_y)
+                print(
+                    f"[dims] video '{video_filename}' (video_id={vid_id}): "
+                    f"asset metadata={annotated_w}x{annotated_h}, "
+                    f"opencv decoded frame={w}x{h}, "
+                    f"scale_x={scale_x:.4f}, scale_y={scale_y:.4f}"
                 )
             frames_coco["images"].append(
                 {
@@ -136,12 +146,21 @@ def extract_frames_and_build_coco(
             continue
 
         new_img_id = old_image_id_to_new[old_img_id]
-        scale_x, scale_y = video_id_to_scale.get(ann.get("video_id"), (1.0, 1.0))
+        vid_id = old_image_id_to_video_id.get(old_img_id)
+        scale_x, scale_y = video_id_to_scale.get(vid_id, (1.0, 1.0))
 
         bbox = ann.get("bbox", [])
+        if new_ann_id < 5:
+            print(
+                f"[dims] annotation {ann.get('id')} (old_image_id={old_img_id}, "
+                f"video_id={vid_id}): bbox_before={bbox}, "
+                f"scale_x={scale_x:.4f}, scale_y={scale_y:.4f}"
+            )
         if bbox and (scale_x != 1.0 or scale_y != 1.0):
             x, y, bw, bh = bbox
             bbox = [x * scale_x, y * scale_y, bw * scale_x, bh * scale_y]
+        if new_ann_id < 5:
+            print(f"[dims] annotation {ann.get('id')}: bbox_after={bbox}")
 
         area = ann.get("area", 0.0) * scale_x * scale_y
 


### PR DESCRIPTION
## Summary
Follow-up to #105 — the offset boxes were still reported after that merge. Root cause: annotations in the video COCO only carry `image_id`, never `video_id` (only the `images` entries do). `ann.get("video_id")` in the rescale lookup always missed, silently falling back to a `(1.0, 1.0)` no-op scale, so the previous fix never actually rescaled anything.

- Resolve each annotation's `video_id` through its `image_id` (via a new `old_image_id_to_video_id` map) instead of reading a field that doesn't exist on annotations.
- Added `[dims]` logging at every stage (asset metadata width/height, video COCO `images` entries, OpenCV-decoded frame size vs. asset metadata + computed scale per video, and bbox before/after scaling for the first few annotations) so any further mismatch can be diagnosed directly from the job logs.

## Test plan
- [ ] Re-run the pipeline on a video dataset with previously-misaligned boxes and confirm they now line up with the extracted frames.
- [ ] If still misaligned, check the `[dims]` log lines to pinpoint where the discrepancy originates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved annotation scaling by applying the correct scale factor for each video.
  * Added validation-focused diagnostics for video dimensions, asset metadata, and bounding-box scaling.
* **Logging**
  * Added detailed processing information, including video identifiers, image dimensions, scale calculations, and annotation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->