### PR TITLE
fix: log frame_id/frame_count mismatch to diagnose video annotation offset

### DIFF
--- a/pipelines/convert_videos_to_frames/utils/processing.py
+++ b/pipelines/convert_videos_to_frames/utils/processing.py
@@ -62,13 +62,21 @@ def extract_frames_and_build_coco(
     # old image_id -> video_id, since annotations only carry image_id, not
     # video_id, and we need to know which video's scale factor to apply.
     old_image_id_to_video_id: dict[int, int] = {}
+    video_id_to_frame_ids: dict[int, list[int]] = {}
     for img in video_coco_data.get("images", []):
         vid = img.get("video_id")
         fid = img.get("frame_id")
         if vid is not None and fid is not None:
             annotated_key_to_old_image_id[(vid, fid)] = img["id"]
+            video_id_to_frame_ids.setdefault(vid, []).append(fid)
         if vid is not None:
             old_image_id_to_video_id[img["id"]] = vid
+
+    for vid, frame_ids in video_id_to_frame_ids.items():
+        print(
+            f"[dims] video_id={vid}: {len(frame_ids)} annotated frame(s), "
+            f"frame_id range=[{min(frame_ids)}, {max(frame_ids)}]"
+        )
 
     frames_coco: dict[str, Any] = {
         "images": [],
@@ -91,6 +99,11 @@ def extract_frames_and_build_coco(
         cap = cv2.VideoCapture(video_path)
         if not cap.isOpened():
             raise RuntimeError(f"Cannot open video: {video_path}")
+        print(
+            f"[dims] video '{video_filename}' (video_id={vid_id}) opencv metadata: "
+            f"fps={cap.get(cv2.CAP_PROP_FPS):.3f}, "
+            f"reported_frame_count={cap.get(cv2.CAP_PROP_FRAME_COUNT):.0f}"
+        )
 
         frame_idx = 0
         while True:
@@ -134,6 +147,13 @@ def extract_frames_and_build_coco(
 
         cap.release()
         print(f"Extracted {frame_idx} frames from '{video_filename}'.")
+        annotated_frame_ids = video_id_to_frame_ids.get(vid_id, [])
+        if annotated_frame_ids and max(annotated_frame_ids) >= frame_idx:
+            print(
+                f"[dims] MISMATCH: video_id={vid_id} has annotated frame_id up to "
+                f"{max(annotated_frame_ids)} but only {frame_idx} frame(s) were "
+                f"decoded — frame_id/frame_idx are out of sync for this video."
+            )
 
     # Convert video track annotations to standard per-frame COCO annotations,
     # rescaling coordinates if the actual decoded frame size differs from the


### PR DESCRIPTION
## Summary
Follow-up to #106. The `[dims]` logs from that fix show `scale_x=1.0000, scale_y=1.0000` for every video — asset metadata and OpenCV-decoded frame size match exactly (2880x1620 both sides) — which rules out a spatial/dimension mismatch entirely. The reported bbox offset must come from somewhere else.

Next suspect: a `frame_id` (annotation platform's frame index) vs `frame_idx` (OpenCV's sequential decode count) desync — e.g. on a variable frame rate video, where OpenCV's `.read()` count can drift from the platform's own frame indexing over the video's duration.

This PR adds diagnostics only, no behavior change:
- Per-video FPS and OpenCV-reported frame count (`CAP_PROP_FPS`, `CAP_PROP_FRAME_COUNT`).
- Per-video annotated `frame_id` range (min/max) and count.
- An explicit `[dims] MISMATCH` warning if an annotated `frame_id` exceeds the number of frames OpenCV actually decoded for that video.

## Test plan
- [ ] Re-run the pipeline on the same offset-affected dataset and check the new log lines for a frame_id/frame_count mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced video frame processing diagnostics to provide clearer information about annotated frame ranges and decoded frame counts.
  * Added detection and reporting when annotation references extend beyond the available video frames.
  * Existing frame extraction and annotation conversion behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->