### PR TITLE
fix: rescale annotation coordinates from Picsellia's video annotation canvas

### DIFF
--- a/pipelines/convert_videos_to_frames/pipeline.py
+++ b/pipelines/convert_videos_to_frames/pipeline.py
@@ -26,9 +26,9 @@ context = create_processing_context_from_config(
     remove_logs_on_completion=False,
 )
 def convert_videos_to_frames_pipeline():
-    video_assets, videos_dir, video_coco_data = download_videos()
+    _video_assets, videos_dir, video_coco_data = download_videos()
     frames_dir, frames_coco, frame_to_video = extract_frames(
-        video_assets, videos_dir, video_coco_data
+        videos_dir, video_coco_data
     )
     new_dataset_version = upload_frames_and_create_dataset(
         frames_dir, frames_coco, frame_to_video

--- a/pipelines/convert_videos_to_frames/steps.py
+++ b/pipelines/convert_videos_to_frames/steps.py
@@ -83,13 +83,14 @@ def download_videos() -> tuple[list, str, dict[str, Any]]:
 
 @step
 def extract_frames(
-    video_assets: list,
     videos_dir: str,
     video_coco_data: dict[str, Any],
 ) -> tuple[str, dict[str, Any], dict[str, str]]:
     """
     Extract every frame from each downloaded video using OpenCV and build a
-    standard image COCO file (track annotations converted to per-frame ones).
+    standard image COCO file (track annotations converted to per-frame ones,
+    with coordinates rescaled from Picsellia's annotation canvas to the
+    actual decoded frame size).
 
     Returns:
         frames_dir: directory containing the extracted JPEG frames.
@@ -97,13 +98,15 @@ def extract_frames(
         frame_to_video: {frame_filename: origin_video_filename}.
     """
     context: PicselliaDatasetProcessingContext = Pipeline.get_active_context()
+    parameters = context.processing_parameters
     frames_dir = os.path.join(context.working_dir, "frames")
 
     frames_coco, frame_to_video = extract_frames_and_build_coco(
         video_coco_data=video_coco_data,
-        video_assets=video_assets,
         videos_dir=videos_dir,
         frames_dir=frames_dir,
+        annotation_canvas_width=parameters.annotation_canvas_width,
+        annotation_canvas_height=parameters.annotation_canvas_height,
     )
     return frames_dir, frames_coco, frame_to_video
 

--- a/pipelines/convert_videos_to_frames/utils/parameters.py
+++ b/pipelines/convert_videos_to_frames/utils/parameters.py
@@ -9,8 +9,14 @@ class ProcessingParameters(Parameters):
         # canvas before display, but its COCO export does not rescale shape
         # coordinates back to the original video resolution.
         self.annotation_canvas_width = self.extract_parameter(
-            keys=["annotation_canvas_width"], expected_type=int, default=2048
+            keys=["annotation_canvas_width"],
+            expected_type=int,
+            default=2048,
+            range_value=(1, 100_000),
         )
         self.annotation_canvas_height = self.extract_parameter(
-            keys=["annotation_canvas_height"], expected_type=int, default=1150
+            keys=["annotation_canvas_height"],
+            expected_type=int,
+            default=1150,
+            range_value=(1, 100_000),
         )

--- a/pipelines/convert_videos_to_frames/utils/parameters.py
+++ b/pipelines/convert_videos_to_frames/utils/parameters.py
@@ -5,3 +5,12 @@ from picsellia_cv_engine.core.parameters import Parameters
 class ProcessingParameters(Parameters):
     def __init__(self, log_data: LogDataType):
         super().__init__(log_data=log_data)
+        # Picsellia's video annotation tool resizes videos to this fixed
+        # canvas before display, but its COCO export does not rescale shape
+        # coordinates back to the original video resolution.
+        self.annotation_canvas_width = self.extract_parameter(
+            keys=["annotation_canvas_width"], expected_type=int, default=2048
+        )
+        self.annotation_canvas_height = self.extract_parameter(
+            keys=["annotation_canvas_height"], expected_type=int, default=1150
+        )

--- a/pipelines/convert_videos_to_frames/utils/processing.py
+++ b/pipelines/convert_videos_to_frames/utils/processing.py
@@ -26,14 +26,21 @@ def _scale_segmentation(
 
 def extract_frames_and_build_coco(
     video_coco_data: dict[str, Any],
-    video_assets: list,
     videos_dir: str,
     frames_dir: str,
+    annotation_canvas_width: int,
+    annotation_canvas_height: int,
 ) -> tuple[dict[str, Any], dict[str, str]]:
     """
     Extract every frame from each video referenced in `video_coco_data`.
     Build a standard COCO file where every frame is an image entry, and
     video track annotations are converted to per-frame image annotations.
+
+    Picsellia's video annotation tool resizes videos to a fixed canvas
+    (`annotation_canvas_width` x `annotation_canvas_height`) before display,
+    but its COCO export does not rescale shape coordinates back to the
+    original video resolution — so annotation coordinates must be rescaled
+    here, from that fixed annotation canvas to the actual decoded frame size.
 
     Returns:
         frames_coco: standard COCO dict ready for import.
@@ -43,18 +50,6 @@ def extract_frames_and_build_coco(
 
     video_id_to_filename: dict[int, str] = {
         v["id"]: v["file_name"] for v in video_coco_data.get("videos", [])
-    }
-
-    # Picsellia's video COCO export never sets width/height on "images"
-    # entries, so the dimensions the annotations were drawn against have to
-    # come from the video asset's own metadata instead (which can differ
-    # from what OpenCV actually decodes).
-    filename_to_asset_dims: dict[str, tuple[int | None, int | None]] = {
-        asset.filename: (asset.width, asset.height) for asset in video_assets
-    }
-    video_id_to_annotated_dims: dict[int, tuple[int | None, int | None]] = {
-        vid: filename_to_asset_dims.get(filename)
-        for vid, filename in video_id_to_filename.items()
     }
 
     # (video_id, frame_id) -> old image_id in the video COCO
@@ -123,15 +118,12 @@ def extract_frames_and_build_coco(
 
             h, w = frame.shape[:2]
             if vid_id not in video_id_to_scale:
-                annotated_w, annotated_h = video_id_to_annotated_dims.get(
-                    vid_id, (None, None)
-                )
-                scale_x = w / annotated_w if annotated_w else 1.0
-                scale_y = h / annotated_h if annotated_h else 1.0
+                scale_x = w / annotation_canvas_width
+                scale_y = h / annotation_canvas_height
                 video_id_to_scale[vid_id] = (scale_x, scale_y)
                 print(
                     f"[dims] video '{video_filename}' (video_id={vid_id}): "
-                    f"asset metadata={annotated_w}x{annotated_h}, "
+                    f"annotation canvas={annotation_canvas_width}x{annotation_canvas_height}, "
                     f"opencv decoded frame={w}x{h}, "
                     f"scale_x={scale_x:.4f}, scale_y={scale_y:.4f}"
                 )
@@ -163,9 +155,8 @@ def extract_frames_and_build_coco(
             )
 
     # Convert video track annotations to standard per-frame COCO annotations,
-    # rescaling coordinates if the actual decoded frame size differs from the
-    # video asset's recorded dimensions (e.g. rotation metadata applied by
-    # Picsellia's ingestion but ignored by OpenCV's decoder).
+    # rescaling coordinates from the fixed annotation canvas to the actual
+    # decoded frame size.
     new_ann_id = 0
     # Log only the first occurrence of each (video_id, category) pair — these
     # are static zones so one sample per zone per video is enough to compare


### PR DESCRIPTION
## Summary
Root cause found (thanks to local repro with run16): Picsellia's video annotation tool resizes videos to a fixed canvas (**2048x1150**) before display, but the video COCO export never rescales shape coordinates back to the original video resolution. Every previous rescale attempt in this pipeline (#105, #106) compared the wrong reference — asset metadata vs. OpenCV-decoded frame size, which already matched each other exactly — so the real mismatch (annotation canvas vs. actual video resolution) was never touched.

- Rescale bbox/area/segmentation coordinates from the fixed annotation canvas to each video's actual decoded frame size.
- Canvas size is now a processing parameter (`annotation_canvas_width` / `annotation_canvas_height`, default `2048x1150`) since it's a property of Picsellia's video annotation tool, not something derivable from the export itself — override it if a different canvas size is ever used.
- Removed the now-unnecessary `video_assets` plumbing through `extract_frames` (asset metadata is no longer part of the rescale logic).

## Verification
Ran the pipeline locally (`run16`) and rendered annotation boxes directly onto the extracted frames, before and after this fix, for `pcb_box_In_Transit` — a genuinely moving tracked object (not a static zone). Before the fix the box consistently landed on the robot arm's body; after applying the 2048x1150 → decoded-size rescale, the box lands on the gripper's tip across multiple frames (38, 50, 70), matching the object it's supposed to track.

## Test plan
- [ ] Re-run the pipeline on the affected dataset and confirm boxes now align with objects in the Picsellia UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video frame processing by correctly rescaling annotation coordinates from the configured annotation canvas to decoded frame dimensions.
  * Added default annotation canvas dimensions to support consistent processing when dimensions are not explicitly provided.
  * Removed reliance on video asset metadata for determining annotation scaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->